### PR TITLE
temporarily exclude new cluster nodes

### DIFF
--- a/paths.sh
+++ b/paths.sh
@@ -8,3 +8,4 @@ export pdb70_build_dir=/cbscratch/${USER}/hhpred_cif_build
 export pdb_dir=/cbscratch/${USER}/databases/pdb/mmcif
 export scop_file=/cbscratch/${USER}/databases/scop/dir.cla.scop.txt_1.75
 export uniprot=/cbscratch/${USER}/databases/uniprot20_2016_02/uniprot20_2016_02
+export EXTRA_CLUSTER_ARGS="-C haswell"

--- a/pdb70_update.sh
+++ b/pdb70_update.sh
@@ -34,7 +34,7 @@ HH_JOB_ID=$(sbatch -p hh -t 2-0 -n 1  -N 1 $EXTRA_CLUSTER_ARGS --parsable -o "${
 #depends on hhblits
 SS_JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 $EXTRA_CLUSTER_ARGS --parsable -o "${LOG_DIR}/cif70_addss.log" -d "afterok:$HH_JOB_ID" ./pdb70_addss.sh)
 CS_JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 $EXTRA_CLUSTER_ARGS --parsable -o "${LOG_DIR}/cif70_cstranslate.log" -d "afterok:$HH_JOB_ID" ./pdb70_cstranslate.sh)
-#CO_JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 --parsable -o "${LOG_DIR}/cif70_cstranslate_old.log" -d "afterok:$HH_JOB_ID" ./pdb70_cstranslate_old.sh)
+#CO_JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 $EXTRA_CLUSTER_ARGS --parsable -o "${LOG_DIR}/cif70_cstranslate_old.log" -d "afterok:$HH_JOB_ID" ./pdb70_cstranslate_old.sh)
 
 #depends on addss
 HM_JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 $EXTRA_CLUSTER_ARGS --parsable -o "${LOG_DIR}/cif70_hhmake.log" -d "afterok:$SS_JOB_ID" ./pdb70_hhmake.sh)

--- a/pdb70_update.sh
+++ b/pdb70_update.sh
@@ -26,19 +26,19 @@ echo "pdb70_update.sh: Syncing folders ..."
 rsync --progress -rlpt -v -z --delete --port=33444 rsync.wwpdb.org::ftp/data/structures/divided/mmCIF/ ${pdb_dir}
 
 LOG_DIR=/usr/users/jsoedin/jobs
-JOB_ID=$(sbatch -p hh -t 2-0 -n 1  -N 1 --parsable -o "${LOG_DIR}/cif70_unfold_cif.log" ./pdb70_unfold_pdb.sh)
-JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 --parsable -o "${LOG_DIR}/cif70_prepare_input.log" -d "afterok:$JOB_ID" ./pdb70_prepare_input.sh)
-JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 --parsable -o "${LOG_DIR}/cif70_hhblits.log" -d "afterok:$JOB_ID" --array=1-11 ./pdb70_hhblits_split.sh)
-HH_JOB_ID=$(sbatch -p hh -t 2-0 -n 1  -N 1 --parsable -o "${LOG_DIR}/cif70_hhblits_merge.log" -d "afterok:$JOB_ID" ./pdb70_hhblits_merge.sh)
+JOB_ID=$(sbatch -p hh -t 2-0 -n 1  -N 1 $EXTRA_CLUSTER_ARGS --parsable -o "${LOG_DIR}/cif70_unfold_cif.log" ./pdb70_unfold_pdb.sh)
+JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 $EXTRA_CLUSTER_ARGS --parsable -o "${LOG_DIR}/cif70_prepare_input.log" -d "afterok:$JOB_ID" ./pdb70_prepare_input.sh)
+JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 $EXTRA_CLUSTER_ARGS --parsable -o "${LOG_DIR}/cif70_hhblits.log" -d "afterok:$JOB_ID" --array=1-11 ./pdb70_hhblits_split.sh)
+HH_JOB_ID=$(sbatch -p hh -t 2-0 -n 1  -N 1 $EXTRA_CLUSTER_ARGS --parsable -o "${LOG_DIR}/cif70_hhblits_merge.log" -d "afterok:$JOB_ID" ./pdb70_hhblits_merge.sh)
 
 #depends on hhblits
-SS_JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 --parsable -o "${LOG_DIR}/cif70_addss.log" -d "afterok:$HH_JOB_ID" ./pdb70_addss.sh)
-CS_JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 --parsable -o "${LOG_DIR}/cif70_cstranslate.log" -d "afterok:$HH_JOB_ID" ./pdb70_cstranslate.sh)
+SS_JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 $EXTRA_CLUSTER_ARGS --parsable -o "${LOG_DIR}/cif70_addss.log" -d "afterok:$HH_JOB_ID" ./pdb70_addss.sh)
+CS_JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 $EXTRA_CLUSTER_ARGS --parsable -o "${LOG_DIR}/cif70_cstranslate.log" -d "afterok:$HH_JOB_ID" ./pdb70_cstranslate.sh)
 #CO_JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 --parsable -o "${LOG_DIR}/cif70_cstranslate_old.log" -d "afterok:$HH_JOB_ID" ./pdb70_cstranslate_old.sh)
 
 #depends on addss
-HM_JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 --parsable -o "${LOG_DIR}/cif70_hhmake.log" -d "afterok:$SS_JOB_ID" ./pdb70_hhmake.sh)
+HM_JOB_ID=$(sbatch -p hh -t 2-0 -n 16 -N 1 $EXTRA_CLUSTER_ARGS --parsable -o "${LOG_DIR}/cif70_hhmake.log" -d "afterok:$SS_JOB_ID" ./pdb70_hhmake.sh)
 
 #depends on hhmake cstranslate
-sbatch -p hh -t 2-0 -n 1 -N 1 -o "${LOG_DIR}/cif70_finalize.log" -d "afterok:${HM_JOB_ID},${CS_JOB_ID}" ./pdb70_finalize.sh
+sbatch -p hh -t 2-0 -n 1 -N 1 $EXTRA_CLUSTER_ARGS -o "${LOG_DIR}/cif70_finalize.log" -d "afterok:${HM_JOB_ID},${CS_JOB_ID}" ./pdb70_finalize.sh
 


### PR DESCRIPTION
There seem to still be problems with the new nodes that prevent creating and updating new PDB70 releases:

```
================================================================================
JobID = 5637574
Partition = hh, Nodelist = hh004
================================================================================
Lmod has detected the following error: Cannot load module
"openmpi/gcc/64/4.0.3_cuda-10.1". At least one of these module(s) must be
loaded:
   gcc/9.2.0

While processing the following module(s):
    Module fullname                 Module Filename
    ---------------                 ---------------
    openmpi/gcc/64/4.0.3_cuda-10.1  /cm/shared/modulefiles/openmpi/gcc/64/4.0.3_cuda-10.1

mkdir: cannot create directory ‘/nvme/n00/jsoedin’: Permission denied
```

The hack here should restrict jobs to our old nodes until the problems are fixed. CC @milot-mirdita, @jessica-andreani